### PR TITLE
Fixed GitHub links and ran into an error when cloning the GitHub so I added the fix to README as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Check out nertivia at https://nertivia.net
 
 1. Fork this repo.
 2. Clone the forked github repo
-3. run `npm i` inside the folder. need to --force or --legacy-peer-deps
+3. run `npm i --legacy-peer-deps`
 4. Rename `example.env` to `.env`
 5. Run the server by `npm run serve`
 6. Navigate to http://local.nertivia.net:8080 and start your development

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Nertivia Client
+
 Check out nertivia at https://nertivia.net
 
 # Development
+
 ### Serve The Client
+
 1. Fork this repo.
 2. Clone the forked github repo
-3. run `npm i` inside the folder.
+3. run `npm i` inside the folder. need to --force or --legacy-peer-deps
 4. Rename `example.env` to `.env`
 5. Run the server by `npm run serve`
 6. Navigate to http://local.nertivia.net:8080 and start your development
 7. Submit a PR :)
 
-
 # Screenshots
+
 ![alt text](https://raw.githubusercontent.com/supertiger1234/nertivia-client-ts/master/preview/Nertivia%20Client.jpg)
 ![alt text](https://raw.githubusercontent.com/supertiger1234/nertivia-client-ts/master/preview/Nertivia%20Servers%20List.jpg)
 ![alt text](https://raw.githubusercontent.com/supertiger1234/nertivia-client-ts/master/preview/Nertivia%20Dashboard.jpg)
-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Check out nertivia at https://nertivia.net
 
 1. Fork this repo.
 2. Clone the forked github repo
-3. run `npm i --legacy-peer-deps`
+3. run `npm i --legacy-peer-deps` inside the folder.
 4. Rename `example.env` to `.env`
 5. Run the server by `npm run serve`
 6. Navigate to http://local.nertivia.net:8080 and start your development

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -16,7 +16,7 @@
           </a>
           <a
             class="button"
-            href="https://github.com/supertiger1234/nertivia-desktop-app/releases"
+            href="https://github.com/Supertigerr/nertivia-desktop-app/releases"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -27,7 +27,7 @@
         <div class="other-buttons">
           <a
             class="button github"
-            href="https://github.com/supertiger1234/"
+            href="https://github.com/Supertigerr/"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
GitHub links on the home page lead to the wrong GitHub so I fixed that. 
When I was cloning the repo I hit an error and needed to use legacy dependencies so I figured I would add it to README to make it easier for others.
